### PR TITLE
Add parentNodeId to createRemoteFileNode to fix cache error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-remote-images",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Gatsby plugin to use gatsby-image on remote images from absolute path string fields on other nodes.",
   "author": "Grayson Hicks <graysonhicks@gmail.com>",
   "main": "gatsby-node.js",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -19,6 +19,7 @@ exports.onCreateNode = async (
     try {
       fileNode = await createRemoteFileNode({
         url: ext ? `${get(node, imagePath)}${ext}` : get(node, imagePath),
+        parentNodeId: node.id,
         store,
         cache,
         createNode,


### PR DESCRIPTION
Added parentNodeId to fix caching error. See https://www.gatsbyjs.org/packages/gatsby-source-filesystem/ for details

Fixes #3 