### PR TITLE
Return from onCreateNode() early if no url

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -16,9 +16,15 @@ exports.onCreateNode = async (
 
   let fileNode
   if (node.internal.type === nodeType) {
+
+    const url = ext ? `${get(node, imagePath)}${ext}` : get(node, imagePath)
+    if (!url) {
+      return 
+    }
+
     try {
       fileNode = await createRemoteFileNode({
-        url: ext ? `${get(node, imagePath)}${ext}` : get(node, imagePath),
+        url,
         parentNodeId: node.id,
         store,
         cache,


### PR DESCRIPTION
As I understand it, if there's no `url`, I don't believe we need to call `createRemoteFileNode()` at all..
unless I'm completely wrong! 