### PR TITLE
added referenceField param

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -9,6 +9,7 @@ exports.onCreateNode = async (
   const {
     nodeType,
     imagePath,
+    referenceField = 'id',
     name = 'localImage',
     auth = {},
     ext = null,
@@ -40,6 +41,6 @@ exports.onCreateNode = async (
   // Adds a field `localImage` or custom name to the node
   // ___NODE appendix tells Gatsby that this field will link to another node
   if (fileNode) {
-    node[`${name}___NODE`] = fileNode.id
+    node[`${name}___NODE___${referenceField}`] = fileNode.${referenceField}
   }
 }


### PR DESCRIPTION
- added referenceField param for specifying which field to use for linking to nodes
- referenceField defaults to `id` to retain existing functionality (non-breaking)

resolves #11 