### PR TITLE
tech(tests): create mocks and test module touchpoints

### DIFF
--- a/__mocks__/gatsby-source-filesystem.js
+++ b/__mocks__/gatsby-source-filesystem.js
@@ -1,0 +1,9 @@
+const gatsbyFs = jest.genMockFromModule('gatsby-source-filesystem');
+
+/**
+ * Thinly mocks `createRemoteFileNode` to test internal touchpoints,
+ * which expect the returned value to have a generated `id` prop via `createNodeId`
+ */
+gatsbyFs.createRemoteFileNode = jest.fn(({ createNodeId }) => ({ id: createNodeId() }));
+
+module.exports = gatsbyFs;

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -47,7 +47,7 @@ function getPath(node, path, ext = null) {
 
 // Creates a file node and associates the parent node to its new child
 async function createImageNode(url, node, options) {
-  const { name, ...restOfOptions } = options
+  const { name, imagePathSegments, ...restOfOptions } = options
   let fileNode
 
   if (!url) {


### PR DESCRIPTION
Note: this does rework the focus of the tests, so if the preference is to not change the existing focus, let me know and I can pivot. The reasons for reworking are below.

Addresses #20 

Previously, the tests were calling the actual `gatsby-source-filesystem` module and generating files/images in the `.cache` directory. The immidate result of this was that adding additional tests using the same `imageUrl`s was causing the module to hit the cache and find it had already generated a file for that url and then subsequent assertions that expected a new file to be returned would fail.

The other impetus for these changes is the practice of not unit testing an underlying technology, but rather testing your touchpoints with that technology. The previous code was making assertions to ensure that `gatsby-source-filesystem` was doing its job, but that's arguably not the responsibility of this module. We should be testing whether our code is forming the expected arguments to the module and that our code which operates on the return value is working as expected.

To address both of these points, these changes mock out the `createRemoteFileNode` method of `gatsby-source-filesystem` to perform the bare minimum logic, and instead stand in as an opportunity to test the arguments our code is passing to it and test the logic we trigger on the return value.

Other changes to the test file were to extract the mocks for the `gatsbyNodeHelpers` object, so that we get a fresh copy for each test, since this was also an issue when adding additional tests that reused the same mock functions for subsequent calls.