### PR TITLE
fix: future-proof functionality through Gatsby schema customization

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": ">2.0.0-alpha"
+    "gatsby": ">=2.2.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/src/__tests__/gatsby-node.js
+++ b/src/__tests__/gatsby-node.js
@@ -1,14 +1,21 @@
 jest.mock('gatsby-source-filesystem');
 
 const { createRemoteFileNode } = require('gatsby-source-filesystem');
-const { onCreateNode } = require(`../gatsby-node`);
+const { onCreateNode, createResolvers } = require(`../gatsby-node`);
 
 const getGatsbyNodeHelperMocks = () => ({
   actions: { createNode: jest.fn() },
   createNodeId: jest.fn().mockReturnValue('remoteFileIdHere'),
+  createResolvers: jest.fn(),
   store: {},
   cache: {},
 });
+
+const mockContext = {
+  nodeModel: {
+    getNodeById: jest.fn(),
+  },
+};
 
 describe('gatsby-plugin-remote-images', () => {
   const baseNode = {
@@ -26,53 +33,74 @@ describe('gatsby-plugin-remote-images', () => {
     imagePath: 'imageUrl',
   };
 
-  it('creates remote file node with defaults', () => {
+  it('creates remote file node with defaults', async () => {
     const node = {
       ...baseNode,
     };
     const options = {
       ...baseOptions,
     };
-    const { actions, createNodeId, store, cache } = getGatsbyNodeHelperMocks();
+    const {
+      actions,
+      createNodeId,
+      createResolvers: mockCreateResolvers,
+      store,
+      cache,
+    } = getGatsbyNodeHelperMocks();
 
-    return onCreateNode(
-      { node, actions, createNodeId, store, cache },
-      options
-    ).then(() => {
-      expect(createNodeId).toHaveBeenCalledTimes(1);
-      expect(createRemoteFileNode).toHaveBeenLastCalledWith({
-        parentNodeId: 'testing',
-        url: node.imageUrl,
-        ext: null,
-        store,
-        cache,
-        createNode: actions.createNode,
-        createNodeId,
-        auth: {},
-      });
-      expect(node['localImage___NODE']).toBe('remoteFileIdHere');
+    await onCreateNode({ node, actions, createNodeId, store, cache }, options);
+    expect(createNodeId).toHaveBeenCalledTimes(1);
+    expect(createRemoteFileNode).toHaveBeenLastCalledWith({
+      parentNodeId: 'testing',
+      url: node.imageUrl,
+      ext: null,
+      store,
+      cache,
+      createNode: actions.createNode,
+      createNodeId,
+      auth: {},
+    });
+
+    createResolvers({ createResolvers: mockCreateResolvers }, options);
+    expect(mockCreateResolvers).toHaveBeenCalledTimes(1);
+    expect(mockCreateResolvers).toHaveBeenLastCalledWith({
+      [options.nodeType]: {
+        localImage: {
+          type: 'File',
+          resolve: expect.any(Function),
+        },
+      },
+    });
+
+    mockContext.nodeModel.getNodeById.mockResolvedValueOnce({
+      id: 'newFileNode',
+    });
+    const fileNodeResolver =
+      mockCreateResolvers.mock.calls[0][0][options.nodeType].localImage.resolve;
+    expect(fileNodeResolver(baseNode, null, mockContext)).resolves.toEqual({
+      id: 'newFileNode',
     });
   });
 
   it('can use the `name` option', () => {
-    const node = {
-      ...baseNode,
-    };
     const options = {
       ...baseOptions,
       name: 'myNewField',
     };
-    const { actions, createNodeId, store, cache } = getGatsbyNodeHelperMocks();
+    const { createResolvers: mockCreateResolvers } = getGatsbyNodeHelperMocks();
 
-    return onCreateNode(
-      { node, actions, createNodeId, store, cache },
-      options
-    ).then(() => {
-      expect(node[`${options.name}___NODE`]).toBe('remoteFileIdHere');
+    createResolvers({ createResolvers: mockCreateResolvers }, options);
+    expect(mockCreateResolvers).toHaveBeenLastCalledWith({
+      [options.nodeType]: {
+        [options.name]: {
+          type: 'File',
+          resolve: expect.any(Function),
+        },
+      },
     });
   });
 
-  it('can use the `ext` option', () => {
+  it('can use the `ext` option', async () => {
     const node = {
       ...baseNode,
       imageUrl: 'https://dummyimage.com/600x400/000/fff',
@@ -88,26 +116,21 @@ describe('gatsby-plugin-remote-images', () => {
     };
     const { actions, createNodeId, store, cache } = getGatsbyNodeHelperMocks();
 
-    return onCreateNode(
-      { node, actions, createNodeId, store, cache },
-      options
-    ).then(() => {
-      expect(createNodeId).toHaveBeenCalledTimes(1);
-      expect(createRemoteFileNode).toHaveBeenLastCalledWith({
-        parentNodeId: 'testing',
-        url: node.imageUrl + options.ext,
-        ext: options.ext,
-        store,
-        cache,
-        createNode: actions.createNode,
-        createNodeId,
-        auth: {},
-      });
-      expect(node['localImage___NODE']).toBe('remoteFileIdHere');
+    await onCreateNode({ node, actions, createNodeId, store, cache }, options);
+    expect(createNodeId).toHaveBeenCalledTimes(1);
+    expect(createRemoteFileNode).toHaveBeenLastCalledWith({
+      parentNodeId: 'testing',
+      url: node.imageUrl + options.ext,
+      ext: options.ext,
+      store,
+      cache,
+      createNode: actions.createNode,
+      createNodeId,
+      auth: {},
     });
   });
 
-  it('can have nested arrays in `imagePath`', () => {
+  it('can have nested arrays in `imagePath`', async () => {
     const node = {
       ...baseNode,
       nodes: [
@@ -128,22 +151,17 @@ describe('gatsby-plugin-remote-images', () => {
     };
     const { actions, createNodeId, store, cache } = getGatsbyNodeHelperMocks();
 
-    return onCreateNode(
-      { node, actions, createNodeId, store, cache },
-      options
-    ).then(() => {
-      expect(createNodeId).toHaveBeenCalledTimes(1);
-      expect(createRemoteFileNode).toHaveBeenLastCalledWith({
-        parentNodeId: 'nested parent',
-        url: node.nodes[0].imageUrl,
-        ext: null,
-        store,
-        cache,
-        createNode: actions.createNode,
-        createNodeId,
-        auth: {},
-      });
-      expect(node.nodes[0]['localImage___NODE']).toBe('remoteFileIdHere');
+    await onCreateNode({ node, actions, createNodeId, store, cache }, options);
+    expect(createNodeId).toHaveBeenCalledTimes(1);
+    expect(createRemoteFileNode).toHaveBeenLastCalledWith({
+      parentNodeId: 'nested parent',
+      url: node.nodes[0].imageUrl,
+      ext: null,
+      store,
+      cache,
+      createNode: actions.createNode,
+      createNodeId,
+      auth: {},
     });
   });
 });


### PR DESCRIPTION
### What

Update the node augmentation logic to fall in line with the direction Gatsby is heading (i.e. remove direct node manipulation) to prevent [immediate](https://github.com/graysonhicks/gatsby-plugin-remote-images/issues/28) and future breakage.

Closes #28

### How

Use Gatsby schema customization ([`createResolvers`](https://www.gatsbyjs.org/docs/schema-customization/#createresolvers-api)) to augment the user-supplied node type by adding a field with a user-supplied name where the resolver for said field returns a `File` node created by [`createRemoteFileNode`](https://www.gatsbyjs.org/packages/gatsby-source-filesystem/#createremotefilenode) (from `gatsby-source-filesystem`).

### Notes

💥  This bumps the required Gatsby peer dependency to `2.2.0` or greater, as that is when the new schema customization APIs were introduced. Not a huge deal, as it has been out since March of 2019, but it is a breaking change and (IMHO) warrants a v2.0.0 release of this plugin.

💡  I didn't see a slick way to communicate between the `onCreateNode` API and the `createResolvers` API, so I introduced a [module-level variable](https://github.com/graysonhicks/gatsby-plugin-remote-images/compare/master...wKovacs64:schema-customization?expand=1#diff-b795d1c35ffc98dcf589692c744446ceR4-R13) to track the relationship between the node to be augmented and the corresponding dynamically created (remote) `File` node. It felt a little weird, but it works. One alternative could be a "hidden" (undocumented) plugin option as both API methods get those passed in, but that felt ever stranger.

🔧  As the new `File` nodes are no longer being directly injected into the source/parent nodes, the previously existing tests were no longer able to verify the correct `File` node was present. In some cases, I adapted them to just ensure things were being called with the appropriate parameters and in other cases I simply removed the node verification assertion. It's not ideal and I suspect they can be improved, but it's better than nothing. A follow-up PR or suggestions to improve them would be great.
