### PR TITLE
Make floppy display on gridsome.org plugins page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# :floppy_disk: gatsby-plugin-remote-images
+# 💾 gatsby-plugin-remote-images
 
 Download images from any string field on another node so that those images can
 be queried with `gatsby-image`.


### PR DESCRIPTION
I wonder why this plugin appears on the gridsom plugin list at all (https://gridsome.org/plugins/gatsby-plugin-remote-images) 🤔