### PR TITLE
Leaf array support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 !index.js
 node_modules/
 package-lock.json
+.vscode
+.history

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-remote-images-d0m3",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Gatsby plugin to use gatsby-image on remote images from absolute path string fields on other nodes.",
   "author": "Grayson Hicks <graysonhicks@gmail.com>",
   "main": "gatsby-node.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-plugin-remote-images-d0m3",
-  "version": "2.2.2",
+  "name": "gatsby-plugin-remote-images",
+  "version": "2.2.0",
   "description": "Gatsby plugin to use gatsby-image on remote images from absolute path string fields on other nodes.",
   "author": "Grayson Hicks <graysonhicks@gmail.com>",
   "main": "gatsby-node.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-plugin-remote-images",
-  "version": "2.2.0",
+  "name": "gatsby-plugin-remote-images-d0m3",
+  "version": "2.2.3",
   "description": "Gatsby plugin to use gatsby-image on remote images from absolute path string fields on other nodes.",
   "author": "Grayson Hicks <graysonhicks@gmail.com>",
   "main": "gatsby-node.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-remote-images-d0m3",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Gatsby plugin to use gatsby-image on remote images from absolute path string fields on other nodes.",
   "author": "Grayson Hicks <graysonhicks@gmail.com>",
   "main": "gatsby-node.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-plugin-remote-images",
-  "version": "2.1.0",
+  "name": "gatsby-plugin-remote-images-d0m3",
+  "version": "2.2.0",
   "description": "Gatsby plugin to use gatsby-image on remote images from absolute path string fields on other nodes.",
   "author": "Grayson Hicks <graysonhicks@gmail.com>",
   "main": "gatsby-node.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "gatsby-plugin-remote-images-d0m3",
-  "version": "2.2.3",
+  "name": "gatsby-plugin-remote-images",
+  "version": "2.1.0",
   "description": "Gatsby plugin to use gatsby-image on remote images from absolute path string fields on other nodes.",
   "author": "Grayson Hicks <graysonhicks@gmail.com>",
   "main": "gatsby-node.js",

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -48,9 +48,9 @@ exports.onCreateNode = async (
   }
 };
 
-function getPaths(node, path, ext) {
+function getPaths(node, path, ext = null) {
   const value = get(node, path);
-  return value.map(path => getPath(node, path, ext));
+  return value.map(url => (ext ? url + ext : url));
 }
 
 // Returns value from path, adding extension when supplied
@@ -73,39 +73,46 @@ async function createImageNodes(urls, node, options) {
     return;
   }
 
-  urls.forEach(async (url, index) => {
-    if (typeof prepareUrl === 'function') {
-      url = prepareUrl({ url, node, index });
-    }
+  const fileNodes = urls
+    .map(async (url, index) => {
+      if (typeof prepareUrl === 'function') {
+        url = prepareUrl({
+          url,
+          node,
+          index,
+        });
+      }
 
-    try {
-      fileNode = await createRemoteFileNode({
-        ...restOfOptions,
-        url,
-        parentNodeId: node.id,
-      });
-    } catch (e) {
-      console.error('gatsby-plugin-remote-images ERROR:', e);
-    }
+      try {
+        fileNode = await createRemoteFileNode({
+          ...restOfOptions,
+          url,
+          parentNodeId: node.id,
+        });
+      } catch (e) {
+        console.error('gatsby-plugin-remote-images ERROR:', e);
+      }
+      return fileNode;
+    })
+    .filter(fileNode => !!fileNode);
 
-    // Store the mapping between the current node and the newly created File node
-    if (fileNode) {
-      // This associates the existing node (of user-specified type) with the new
-      // File nodes created via createRemoteFileNode. The new File nodes will be
-      // resolved dynamically through the Gatsby schema customization
-      // createResolvers API and which File node gets resolved for each new field
-      // on a given node of the user-specified type is determined by the contents
-      // of this mapping. The keys are based on the ID of the parent node (of
-      // user-specified type) and the values are each a nested mapping of the new
-      // image File field name to the ID of the new File node.
-      const cacheKey = getCacheKeyForNodeId(node.id);
-      const existingFileNodeMap = await options.cache.get(cacheKey);
-      await options.cache.set(cacheKey, {
-        ...existingFileNodeMap,
-        [name]: [...existingFileNodeMap[name], fileNode.id],
-      });
-    }
-  });
+  // Store the mapping between the current node and the newly created File node
+  if (fileNodes.length) {
+    // This associates the existing node (of user-specified type) with the new
+    // File nodes created via createRemoteFileNode. The new File nodes will be
+    // resolved dynamically through the Gatsby schema customization
+    // createResolvers API and which File node gets resolved for each new field
+    // on a given node of the user-specified type is determined by the contents
+    // of this mapping. The keys are based on the ID of the parent node (of
+    // user-specified type) and the values are each a nested mapping of the new
+    // image File field name to the ID of the new File node.
+    const cacheKey = getCacheKeyForNodeId(node.id);
+    const existingFileNodeMap = await options.cache.get(cacheKey);
+    await options.cache.set(cacheKey, {
+      ...existingFileNodeMap,
+      [name]: fileNodes.map(({ id }) => id),
+    });
+  }
 }
 
 // Creates a file node and associates the parent node to its new child

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,5 +1,6 @@
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
 const get = require('lodash/get');
+const isArray = require('lodash/isArray');
 
 exports.onCreateNode = async (
   { node, actions, store, cache, createNodeId },
@@ -13,6 +14,7 @@ exports.onCreateNode = async (
     auth = {},
     ext = null,
     prepareUrl = null,
+    type = 'object',
   } = options;
   const createImageNodeOptions = {
     store,
@@ -36,12 +38,20 @@ exports.onCreateNode = async (
         imagePathSegments,
         ...createImageNodeOptions,
       });
+    } else if (type === 'array') {
+      const urls = getPaths(node, imagePath, ext);
+      await createImageNodes(urls, node, createImageNodeOptions);
     } else {
       const url = getPath(node, imagePath, ext);
       await createImageNode(url, node, createImageNodeOptions);
     }
   }
 };
+
+function getPaths(node, path, ext) {
+  const value = get(node, path);
+  return value.map(path => getPath(node, path, ext));
+}
 
 // Returns value from path, adding extension when supplied
 function getPath(node, path, ext = null) {
@@ -55,6 +65,49 @@ function getCacheKeyForNodeId(nodeId) {
   return `gatsby-plugin-remote-images-${nodeId}`;
 }
 
+async function createImageNodes(urls, node, options) {
+  const { name, imagePathSegments, prepareUrl, ...restOfOptions } = options;
+  let fileNode;
+
+  if (!urls) {
+    return;
+  }
+
+  urls.forEach(async (url, index) => {
+    if (typeof prepareUrl === 'function') {
+      url = prepareUrl({ url, node, index });
+    }
+
+    try {
+      fileNode = await createRemoteFileNode({
+        ...restOfOptions,
+        url,
+        parentNodeId: node.id,
+      });
+    } catch (e) {
+      console.error('gatsby-plugin-remote-images ERROR:', e);
+    }
+
+    // Store the mapping between the current node and the newly created File node
+    if (fileNode) {
+      // This associates the existing node (of user-specified type) with the new
+      // File nodes created via createRemoteFileNode. The new File nodes will be
+      // resolved dynamically through the Gatsby schema customization
+      // createResolvers API and which File node gets resolved for each new field
+      // on a given node of the user-specified type is determined by the contents
+      // of this mapping. The keys are based on the ID of the parent node (of
+      // user-specified type) and the values are each a nested mapping of the new
+      // image File field name to the ID of the new File node.
+      const cacheKey = getCacheKeyForNodeId(node.id);
+      const existingFileNodeMap = await options.cache.get(cacheKey);
+      await options.cache.set(cacheKey, {
+        ...existingFileNodeMap,
+        [name]: [...existingFileNodeMap[name], fileNode.id],
+      });
+    }
+  });
+}
+
 // Creates a file node and associates the parent node to its new child
 async function createImageNode(url, node, options) {
   const { name, imagePathSegments, prepareUrl, ...restOfOptions } = options;
@@ -65,7 +118,7 @@ async function createImageNode(url, node, options) {
   }
 
   if (typeof prepareUrl === 'function') {
-    url = prepareUrl(url);
+    url = prepareUrl({ url, node });
   }
 
   try {
@@ -133,19 +186,39 @@ async function createImageNodesInArrays(path, node, options) {
 }
 
 exports.createResolvers = ({ cache, createResolvers }, options) => {
-  const { nodeType, name = 'localImage' } = options;
+  const { nodeType, name = 'localImage', type = 'object' } = options;
 
-  const resolvers = {
-    [nodeType]: {
-      [name]: {
-        type: 'File',
-        resolve: async (source, _, context) => {
-          const fileNodeMap = await cache.get(getCacheKeyForNodeId(source.id));
-          return context.nodeModel.getNodeById({ id: fileNodeMap[name] });
+  if (type === 'array') {
+    const resolvers = {
+      [nodeType]: {
+        [name]: {
+          type: '[File]',
+          resolve: async (source, _, context) => {
+            const fileNodeMap = await cache.get(
+              getCacheKeyForNodeId(source.id)
+            );
+            return fileNodeMap[name].map(id =>
+              context.nodeModel.getNodeById({ id })
+            );
+          },
         },
       },
-    },
-  };
-
-  createResolvers(resolvers);
+    };
+    createResolvers(resolvers);
+  } else {
+    const resolvers = {
+      [nodeType]: {
+        [name]: {
+          type: 'File',
+          resolve: async (source, _, context) => {
+            const fileNodeMap = await cache.get(
+              getCacheKeyForNodeId(source.id)
+            );
+            return context.nodeModel.getNodeById({ id: fileNodeMap[name] });
+          },
+        },
+      },
+    };
+    createResolvers(resolvers);
+  }
 };

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -73,28 +73,30 @@ async function createImageNodes(urls, node, options) {
     return;
   }
 
-  const fileNodes = urls
-    .map(async (url, index) => {
-      if (typeof prepareUrl === 'function') {
-        url = prepareUrl({
-          url,
-          node,
-          index,
-        });
-      }
+  const fileNodes = (
+    await Promise.all(
+      urls.map(async (url, index) => {
+        if (typeof prepareUrl === 'function') {
+          url = prepareUrl({
+            url,
+            node,
+            index,
+          });
+        }
 
-      try {
-        fileNode = await createRemoteFileNode({
-          ...restOfOptions,
-          url,
-          parentNodeId: node.id,
-        });
-      } catch (e) {
-        console.error('gatsby-plugin-remote-images ERROR:', e);
-      }
-      return fileNode;
-    })
-    .filter(fileNode => !!fileNode);
+        try {
+          fileNode = await createRemoteFileNode({
+            ...restOfOptions,
+            url,
+            parentNodeId: node.id,
+          });
+        } catch (e) {
+          console.error('gatsby-plugin-remote-images ERROR:', e);
+        }
+        return fileNode;
+      })
+    )
+  ).filter(fileNode => !!fileNode);
 
   // Store the mapping between the current node and the newly created File node
   if (fileNodes.length) {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,6 +1,5 @@
 const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
 const get = require('lodash/get');
-const isArray = require('lodash/isArray');
 
 exports.onCreateNode = async (
   { node, actions, store, cache, createNodeId },

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -206,6 +206,9 @@ exports.createResolvers = ({ cache, createResolvers }, options) => {
             const fileNodeMap = await cache.get(
               getCacheKeyForNodeId(source.id)
             );
+            if (!fileNodeMap || !fileNodeMap[name]) {
+              return [];
+            }
             return fileNodeMap[name].map(id =>
               context.nodeModel.getNodeById({ id })
             );

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -77,11 +77,7 @@ async function createImageNodes(urls, node, options) {
     await Promise.all(
       urls.map(async (url, index) => {
         if (typeof prepareUrl === 'function') {
-          url = prepareUrl({
-            url,
-            node,
-            index,
-          });
+          url = prepareUrl(url);
         }
 
         try {
@@ -127,7 +123,7 @@ async function createImageNode(url, node, options) {
   }
 
   if (typeof prepareUrl === 'function') {
-    url = prepareUrl({ url, node });
+    url = prepareUrl(url);
   }
 
   try {


### PR DESCRIPTION
This replaces #44 
Add support for array of urls, instead of a single url at the leaf node.
I had to add a `type` option that should be set to `array` in that case. It would be possible to detect the array at runtime of course, but I didn't know how to detect it in the resolver, it didn't seem possible.