### PR TITLE
Adding an option to skip undefined urls

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,6 +20,7 @@ exports.onCreateNode = async (
     prepareUrl = null,
     type = 'object',
     silent = false,
+    skipUndefinedUrls = false,
   } = options;
   const createImageNodeOptions = {
     store,
@@ -31,6 +32,7 @@ exports.onCreateNode = async (
     ext,
     name,
     prepareUrl,
+    skipUndefinedUrls,
   };
 
   if (node.internal.type === nodeType) {
@@ -101,6 +103,8 @@ async function createImageNodes(urls, node, options, reporter, silent) {
           url = prepareUrl(url);
         }
 
+        if (options.skipUndefinedUrls && !url) return 
+
         try {
           fileNode = await createRemoteFileNode({
             ...restOfOptions,
@@ -144,6 +148,8 @@ async function createImageNode(url, node, options, reporter, silent) {
   if (typeof prepareUrl === 'function') {
     url = prepareUrl(url);
   }
+
+  if (options.skipUndefinedUrls && !url) return 
 
   try {
     fileNode = await createRemoteFileNode({


### PR DESCRIPTION
Just found this plugin today, it's extremely helpful! 

I hit this same issue: https://github.com/graysonhicks/gatsby-plugin-remote-images/issues/120 

I'm using this plugin with another which creates a structure with a lot of null values so I've added a quick, minimal-changes fix.

This adds an option, `skipUndefinedUrls`, which short-circuits node creation where either the `url` passed to `createImageNode()` is falsy or the `url` returned from `prepareUrl()` (when defined) is falsy. This skips undefined `urls` and adds an easy way for the user to implement their own "undefined" values by returning undefined from the `prepareUrl()` function.

Example of using this change to set options to skip both `null` `urls` and `urls` which are `'N/A'`: 

```ts
  plugins: [
    {
      resolve: `gatsby-plugin-remote-images`,
      options: {
        nodeType: 'MyRemoteNode',
        imagePath: 'data.imageUrl',
        // ** ALL OPTIONAL BELOW HERE: **
        skipUndefinedUrls: true,
        prepareUrl: (url: string) => {
          if (!url || url === 'N/A') return undefined
          return url
        },
      },
    },
  ]
```

Default behavior (without setting `skipUndefinedUrls: true` is unchanged so that the currently implemented errors aren't affected. 