### PR TITLE
Support local working image CDN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ module.exports = {
 | type              | Tell the plugin that the leaf node is an _array_ of images instead of one single string. Only option here is `array`. For example usage, [see here](#handling-an-array-of-image-urls).                                                                                                                                                           | ❌       | `object`     |
 | silent            | Set to `true` to silence image load errors in the console.                                                                                                                                                                                                                                                                                       | ❌       | `boolean`    |
 | skipUndefinedUrls | This skips undefined `urls` and adds an easy way for the user to implement their own "undefined" values by returning undefined from the `prepareUrl()` function. See [here](https://github.com/graysonhicks/gatsby-plugin-remote-images/pull/134#issue-1568549719).                                                                              | ❌       | `boolean`    |
+| mode              | This enables Gatsby ImageCDN support when set to `'cdn'`                                                                                                                                                                                                                                                                                         | ❌       | `null`       |
 
 #### Example Config with Optional Options
 
@@ -73,6 +74,7 @@ module.exports = {
         auth: { htaccess_user: `USER`, htaccess_pass: `PASSWORD` },
         ext: '.jpg',
         prepareUrl: url => (url.startsWith('//') ? `https:${url}` : url),
+        mode: 'cdn',
       },
     },
   ],
@@ -160,6 +162,21 @@ allMyNodes {
         childImageSharp {
           gatsbyImageData(width: 400)
         }
+      }
+    }
+  }
+}
+```
+
+Or if `mode` is set to `cdn`, we can query with the ImageCDN supported query
+like so:
+
+```graphql
+allMyNodes {
+  edges {
+    node {
+      localImage {
+        gatsbyImage(width: 400)
       }
     }
   }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,17 +1,13 @@
-"use strict";
+'use strict';
 
+const { createRemoteFileNode } = require(`gatsby-source-filesystem`);
 const {
-  createRemoteFileNode
-} = require(`gatsby-source-filesystem`);
-const {
-  addRemoteFilePolyfillInterface
+  addRemoteFilePolyfillInterface,
 } = require('gatsby-plugin-utils/polyfill-remote-file');
 const get = require('lodash/get');
 const probe = require('probe-image-size');
 let i = 0;
-exports.pluginOptionsSchema = ({
-  Joi
-}) => {
+exports.pluginOptionsSchema = ({ Joi }) => {
   return Joi.object({
     nodeType: Joi.string().required(),
     imagePath: Joi.string().required(),
@@ -21,45 +17,42 @@ exports.pluginOptionsSchema = ({
     prepareUrl: Joi.function(),
     type: Joi.object(),
     silent: Joi.boolean(),
-    skipUndefinedUrls: Joi.boolean()
+    skipUndefinedUrls: Joi.boolean(),
+    mode: Joi.string(),
   });
 };
 const isImageCdnEnabled = () => {
-  return process.env.GATSBY_CLOUD_IMAGE_CDN === '1' || process.env.GATSBY_CLOUD_IMAGE_CDN === 'true';
+  return (
+    process.env.GATSBY_CLOUD_IMAGE_CDN === '1' ||
+    process.env.GATSBY_CLOUD_IMAGE_CDN === 'true'
+  );
 };
-exports.createSchemaCustomization = ({
-  actions,
-  schema
-}) => {
-  if (isImageCdnEnabled()) {
-    const RemoteImageFileType = addRemoteFilePolyfillInterface(schema.buildObjectType({
-      name: 'RemoteImageFile',
-      fields: {
-        id: 'ID!'
-      },
-      interfaces: ['Node', 'RemoteFile'],
-      extensions: {
-        infer: true
+exports.createSchemaCustomization = ({ actions, schema }, { mode }) => {
+  if (isImageCdnEnabled() || mode === 'cdn') {
+    const RemoteImageFileType = addRemoteFilePolyfillInterface(
+      schema.buildObjectType({
+        name: 'RemoteImageFile',
+        fields: {
+          id: 'ID!',
+        },
+        interfaces: ['Node', 'RemoteFile'],
+        extensions: {
+          infer: true,
+        },
+      }),
+      {
+        schema,
+        actions,
       }
-    }), {
-      schema,
-      actions
-    });
+    );
     actions.createTypes([RemoteImageFileType]);
   }
 };
-exports.onCreateNode = async ({
-  node,
-  actions,
-  store,
-  cache,
-  createNodeId,
-  createContentDigest,
-  reporter
-}, options) => {
-  const {
-    createNode
-  } = actions;
+exports.onCreateNode = async (
+  { node, actions, store, cache, createNodeId, createContentDigest, reporter },
+  options
+) => {
+  const { createNode } = actions;
   const {
     nodeType,
     imagePath,
@@ -68,7 +61,8 @@ exports.onCreateNode = async ({
     ext = null,
     prepareUrl = null,
     type = 'object',
-    silent = false
+    silent = false,
+    mode,
   } = options;
   const createImageNodeOptions = {
     store,
@@ -79,7 +73,8 @@ exports.onCreateNode = async ({
     auth,
     ext,
     name,
-    prepareUrl
+    prepareUrl,
+    mode,
   };
   if (node.internal.type === nodeType) {
     // Check if any part of the path indicates the node is an array and splits at those indicators
@@ -90,12 +85,24 @@ exports.onCreateNode = async ({
     if (imagePathSegments.length) {
       const urls = await getAllFilesUrls(imagePathSegments[0], node, {
         imagePathSegments,
-        ...createImageNodeOptions
+        ...createImageNodeOptions,
       });
-      await createImageNodes(urls, node, createImageNodeOptions, reporter, silent);
+      await createImageNodes(
+        urls,
+        node,
+        createImageNodeOptions,
+        reporter,
+        silent
+      );
     } else if (type === 'array') {
       const urls = getPaths(node, imagePath, ext);
-      await createImageNodes(urls, node, createImageNodeOptions, reporter, silent);
+      await createImageNodes(
+        urls,
+        node,
+        createImageNodeOptions,
+        reporter,
+        silent
+      );
     } else {
       const url = getPath(node, imagePath, ext);
       await createImageNode(url, node, createImageNodeOptions, reporter);
@@ -105,7 +112,7 @@ exports.onCreateNode = async ({
 function getPaths(node, path, ext = null) {
   const value = get(node, path);
   if (value) {
-    return value.map(url => ext ? url + ext : url);
+    return value.map(url => (ext ? url + ext : url));
   }
 }
 
@@ -122,6 +129,7 @@ function getCacheKeyForNodeId(nodeId) {
 async function createImageNodes(urls, node, options, reporter, silent) {
   const {
     name,
+    mode,
     imagePathSegments,
     prepareUrl,
     ...restOfOptions
@@ -130,25 +138,29 @@ async function createImageNodes(urls, node, options, reporter, silent) {
   if (!urls) {
     return;
   }
-  const fileNodes = (await Promise.all(urls.map(async (url, index) => {
-    if (typeof prepareUrl === 'function') {
-      url = prepareUrl(url);
-    }
-    if (options.skipUndefinedUrls && !url) return;
-    try {
-      fileNode = await createRemoteFileNode({
-        ...restOfOptions,
-        url,
-        parentNodeId: node.id
-      });
-      reporter.verbose(`Created image from ${url}`);
-    } catch (e) {
-      if (!silent) {
-        reporter.error(`gatsby-plugin-remote-images ERROR:`, new Error(e));
-      }
-    }
-    return fileNode;
-  }))).filter(fileNode => !!fileNode);
+  const fileNodes = (
+    await Promise.all(
+      urls.map(async (url, index) => {
+        if (typeof prepareUrl === 'function') {
+          url = prepareUrl(url);
+        }
+        if (options.skipUndefinedUrls && !url) return;
+        try {
+          fileNode = await createRemoteFileNode({
+            ...restOfOptions,
+            url,
+            parentNodeId: node.id,
+          });
+          reporter.verbose(`Created image from ${url}`);
+        } catch (e) {
+          if (!silent) {
+            reporter.error(`gatsby-plugin-remote-images ERROR:`, new Error(e));
+          }
+        }
+        return fileNode;
+      })
+    )
+  ).filter(fileNode => !!fileNode);
 
   // Store the mapping between the current node and the newly created File node
   if (fileNodes.length) {
@@ -164,9 +176,7 @@ async function createImageNodes(urls, node, options, reporter, silent) {
     const existingFileNodeMap = await options.cache.get(cacheKey);
     await options.cache.set(cacheKey, {
       ...existingFileNodeMap,
-      [name]: fileNodes.map(({
-        id
-      }) => id)
+      [name]: fileNodes.map(({ id }) => id),
     });
   }
 }
@@ -175,6 +185,7 @@ async function createImageNodes(urls, node, options, reporter, silent) {
 async function createImageNode(url, node, options, reporter, silent) {
   const {
     name,
+    mode,
     imagePathSegments,
     prepareUrl,
     ...restOfOptions
@@ -186,7 +197,7 @@ async function createImageNode(url, node, options, reporter, silent) {
   }
   if (options.skipUndefinedUrls && !url) return;
   try {
-    if (isImageCdnEnabled()) {
+    if (isImageCdnEnabled() || mode === 'cdn') {
       fileNodeId = options.createNodeId(`RemoteImageFile >>> ${node.id}`);
       const metadata = await probe(url);
       await options.createNode({
@@ -199,8 +210,8 @@ async function createImageNode(url, node, options, reporter, silent) {
         mimeType: metadata.mime,
         internal: {
           type: 'RemoteImageFile',
-          contentDigest: node.internal.contentDigest
-        }
+          contentDigest: node.internal.contentDigest,
+        },
       });
       if (!silent) {
         reporter.verbose(`Created RemoteImageFile node from ${url}`);
@@ -209,7 +220,7 @@ async function createImageNode(url, node, options, reporter, silent) {
       fileNode = await createRemoteFileNode({
         ...restOfOptions,
         url,
-        parentNodeId: node.id
+        parentNodeId: node.id,
       });
       fileNodeId = fileNode.id;
       if (!silent) {
@@ -221,21 +232,24 @@ async function createImageNode(url, node, options, reporter, silent) {
       reporter.error(`gatsby-plugin-remote-images ERROR:`, new Error(e));
     }
     ++i;
-    fileNode = await options.createNode({
-      id: options.createNodeId(`${i}`),
-      parent: node.id,
-      internal: {
-        type: 'File',
-        mediaType: 'application/octet-stream',
-        contentDigest: options.createContentDigest(`${i}`)
+    fileNode = await options.createNode(
+      {
+        id: options.createNodeId(`${i}`),
+        parent: node.id,
+        internal: {
+          type: 'File',
+          mediaType: 'application/octet-stream',
+          contentDigest: options.createContentDigest(`${i}`),
+        },
+      },
+      {
+        name: 'gatsby-source-filesystem',
       }
-    }, {
-      name: 'gatsby-source-filesystem'
-    });
+    );
   }
 
   // Store the mapping between the current node and the newly created File node
-  if (fileNode || isImageCdnEnabled()) {
+  if (fileNode || isImageCdnEnabled() || mode === 'cdn') {
     // This associates the existing node (of user-specified type) with the new
     // File nodes created via createRemoteFileNode. The new File nodes will be
     // resolved dynamically through the Gatsby schema customization
@@ -248,7 +262,7 @@ async function createImageNode(url, node, options, reporter, silent) {
     const existingFileNodeMap = await options.cache.get(cacheKey);
     await options.cache.set(cacheKey, {
       ...existingFileNodeMap,
-      [name]: fileNode ? fileNode.id : fileNodeId
+      [name]: fileNode ? fileNode.id : fileNodeId,
     });
   }
 }
@@ -258,64 +272,75 @@ async function getAllFilesUrls(path, node, options) {
   if (!path || !node) {
     return;
   }
-  const {
-    imagePathSegments,
-    ext
-  } = options;
+  const { imagePathSegments, ext } = options;
   const pathIndex = imagePathSegments.indexOf(path),
     isPathToLeafProperty = pathIndex === imagePathSegments.length - 1,
     nextValue = getPath(node, path, isPathToLeafProperty ? ext : null);
 
   // @TODO: Need logic to handle if the leaf node is an array to then shift
   // to the function of createImageNodes.
-  return Array.isArray(nextValue) && !isPathToLeafProperty ?
-  // Recursively call function with next path segment for each array element
-  (await Promise.all(nextValue.map(item => getAllFilesUrls(imagePathSegments[pathIndex + 1], item, options)))).reduce((arr, row) => arr.concat(row), []) :
-  // otherwise, handle leaf node
-  nextValue;
+  return Array.isArray(nextValue) && !isPathToLeafProperty
+    ? // Recursively call function with next path segment for each array element
+      (
+        await Promise.all(
+          nextValue.map(item =>
+            getAllFilesUrls(imagePathSegments[pathIndex + 1], item, options)
+          )
+        )
+      ).reduce((arr, row) => arr.concat(row), [])
+    : // otherwise, handle leaf node
+      nextValue;
 }
-exports.createResolvers = ({
-  cache,
-  createResolvers
-}, options) => {
+exports.createResolvers = ({ cache, createResolvers }, options) => {
   const {
     nodeType,
+    mode,
     imagePath,
     name = 'localImage',
-    type = 'object'
+    type = 'object',
   } = options;
   if (type === 'array' || imagePath.includes('[].')) {
     const resolvers = {
       [nodeType]: {
         [name]: {
-          type: isImageCdnEnabled() ? '[RemoteImageFile]' : '[File]',
+          type:
+            isImageCdnEnabled() || mode === 'cdn'
+              ? '[RemoteImageFile]'
+              : '[File]',
           resolve: async (source, _, context) => {
-            const fileNodeMap = await cache.get(getCacheKeyForNodeId(source.id));
+            const fileNodeMap = await cache.get(
+              getCacheKeyForNodeId(source.id)
+            );
             if (!fileNodeMap || !fileNodeMap[name]) {
               return [];
             }
-            return fileNodeMap[name].map(id => context.nodeModel.getNodeById({
-              id
-            }));
-          }
-        }
-      }
+            return fileNodeMap[name].map(id =>
+              context.nodeModel.getNodeById({
+                id,
+              })
+            );
+          },
+        },
+      },
     };
     createResolvers(resolvers);
   } else {
     const resolvers = {
       [nodeType]: {
         [name]: {
-          type: isImageCdnEnabled() ? 'RemoteImageFile' : 'File',
+          type:
+            isImageCdnEnabled() || mode === 'cdn' ? 'RemoteImageFile' : 'File',
           resolve: async (source, _, context) => {
-            const fileNodeMap = await cache.get(getCacheKeyForNodeId(source.id));
+            const fileNodeMap = await cache.get(
+              getCacheKeyForNodeId(source.id)
+            );
             if (!fileNodeMap) return null;
             return context.nodeModel.getNodeById({
-              id: fileNodeMap[name]
+              id: fileNodeMap[name],
             });
-          }
-        }
-      }
+          },
+        },
+      },
     };
     createResolvers(resolvers);
   }


### PR DESCRIPTION
## Purpose

Fixes an issue I introduced with #123 where locally you'll get issues running your site as the syntax will be for `gatsbyImageData` rather than the `gatsbyImage` ImageCDN query.

This also re-introduces the `mode` option initially purposed to control ImageCDN support and makes it so that either `mode` or the `GATSBY_CLOUD_IMAGE_CDN` env var that is provided by Gatsby Cloud during Gatsby Cloud builds will trigger the plugin to create ImageCDN compatible nodes.