### PR TITLE
Include skipUndefinedUrls in options

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -68,6 +68,7 @@ exports.onCreateNode = async ({
     ext = null,
     prepareUrl = null,
     type = 'object',
+    skipUndefinedUrls = false,
     silent = false
   } = options;
   const createImageNodeOptions = {
@@ -79,6 +80,7 @@ exports.onCreateNode = async ({
     auth,
     ext,
     name,
+    skipUndefinedUrls,
     prepareUrl
   };
   if (node.internal.type === nodeType) {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -64,6 +64,7 @@ exports.onCreateNode = async (
     ext = null,
     prepareUrl = null,
     type = 'object',
+    skipUndefinedUrls = false,
     silent = false,
   } = options;
   const createImageNodeOptions = {
@@ -75,6 +76,7 @@ exports.onCreateNode = async (
     auth,
     ext,
     name,
+    skipUndefinedUrls,
     prepareUrl,
   };
 


### PR DESCRIPTION
I noticed that #134, which resolved #120, wasn't working as I expected. 

On debugging, it looked like some of the changes in the original PR were lost in the merge, so that the plugin always saw 'skipUndefinedImages' as undefined, even if it was set to true. 