### PR TITLE
Pass `silent` parameter to createImageNode function

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -108,7 +108,7 @@ exports.onCreateNode = async (
       );
     } else {
       const url = getPath(node, imagePath, ext);
-      await createImageNode(url, node, createImageNodeOptions, reporter);
+      await createImageNode(url, node, createImageNodeOptions, reporter, silent);
     }
   }
 };


### PR DESCRIPTION
The plugin is reporting errors even though the option `silent: true` is set in `gatsby-node.{ts,js}`

This change includes the `silent` parameter from the plugin's configuration when calling the `createImageNode` function.